### PR TITLE
Fix formatting flag for GNU `stat`

### DIFF
--- a/src/batwatch.sh
+++ b/src/batwatch.sh
@@ -52,7 +52,7 @@ watcher_entr_watch() {
 		ENTR_ARGS+=('-c')
 	fi
 
-	entr "${ENTR_ARGS[@]}" \
+	pager_exec entr "${ENTR_ARGS[@]}" \
 		"$EXECUTABLE_BAT" "${BAT_ARGS[@]}" \
 		--terminal-width="$OPT_TERMINAL_WIDTH" \
 		--paging=never \
@@ -77,7 +77,7 @@ determine_stat_variant() {
 
   local varient name cmd ts
 
-  for varient in "gnu -c %z" "bsd -f %m"; do
+  for varient in "gnu -c %Z" "bsd -f %m"; do
     name="${varient%% *}" cmd="stat ${varient#* }"
 
     # keep the results of the stash command
@@ -123,10 +123,11 @@ watcher_poll_watch() {
 				clear
 			fi
 
-			"$EXECUTABLE_BAT" "${BAT_ARGS[@]}" \
+			pager_exec "$EXECUTABLE_BAT" "${BAT_ARGS[@]}" \
 				--terminal-width="$OPT_TERMINAL_WIDTH" \
 				--paging=never \
 				"${files[@]}"
+
 		fi
 
 		local i=0
@@ -141,7 +142,13 @@ watcher_poll_watch() {
 			((i++))
 		done
 
-		sleep 1
+    read -r -t 1 input
+
+    if [[ "$input" =~ [q|Q] ]]; then
+      exit
+    fi
+
+    input=
 	done
 
 	"${POLL_STAT_COMMAND[@]}" "$@"
@@ -256,5 +263,5 @@ main() {
  	return $?
 }
 
-pager_exec main
+main
 exit $?

--- a/src/batwatch.sh
+++ b/src/batwatch.sh
@@ -78,17 +78,17 @@ determine_stat_variant() {
   local varient name cmd ts
 
   for varient in "gnu -c %Z" "bsd -f %m"; do
-    name="${varient%% *}" cmd="stat ${varient#* }"
+    read -r name flags <<< "$varient"
 
-    # keep the results of the stash command
+    # save the results of the stat command
     if read -r ts <               \
-      <( ${cmd} "$0" 2>/dev/null ); then
+      <( stat ${flags} "$0" 2>/dev/null ); then
 
       # verify that the value is an epoch timetamp
       # before proceeding
       if [[ "${ts}" =~ ^[0-9]+$ ]]; then
 
-        POLL_STAT_COMMAND=( ${cmd} )
+        POLL_STAT_COMMAND=( stat ${flags} )
         POLL_STAT_VARIANT="$name"
         return 0
 

--- a/test/snapshot/batwatch/test_displayed.stdout.snapshot
+++ b/test/snapshot/batwatch/test_displayed.stdout.snapshot
@@ -1,0 +1,4 @@
+echo Hello, test world!
+if true; then
+	! true
+fi

--- a/test/snapshot/batwatch/test_help.stdout.snapshot
+++ b/test/snapshot/batwatch/test_help.stdout.snapshot
@@ -1,0 +1,1 @@
+Usage: batwatch [--watcher entr|poll][--[no-]clear] <file> [<file> ...]

--- a/test/suite/batwatch.sh
+++ b/test/suite/batwatch.sh
@@ -1,12 +1,32 @@
+#!/bin/bash
+
 setup() {
 	use_shim 'batwatch'
 }
 
 test:version() {
 	description "Test 'batwatch --version'"
-	snapshot stdout
-	snapshot stderr
+  snapshot stdout
+  snapshot stderr
 
 	batwatch --version | awk 'FNR <= 1 { print $1 }'
 	batwatch --version | awk 'p{print} /^$/ { p=1 }'
+}
+
+test:help() {
+	description "Test 'batwatch --help'"
+  snapshot stdout
+  batwatch --help
+
+  assert batwatch --help
+  batwatch --help | grep -q 'Usage'
+}
+
+test:watcher() {
+	description "Test 'batwatch <file>'"
+  fail "No longer fails silently due to incorrect flag to stat."
+
+  # Refactored to get here, but when it passes it will loop forever.
+
+  assert batwatch $0
 }

--- a/test/suite/batwatch.sh
+++ b/test/suite/batwatch.sh
@@ -22,11 +22,10 @@ test:help() {
   batwatch --help | grep -q 'Usage'
 }
 
-test:watcher() {
-	description "Test 'batwatch <file>'"
-  fail "No longer fails silently due to incorrect flag to stat."
+test:displayed() {
+	description "Test 'batwatch <file>': <file> should be displayed'"
+  snapshot stdout
 
-  # Refactored to get here, but when it passes it will loop forever.
-
-  assert batwatch $0
+  batwatch --no-clear --watcher poll file.sh <<< "q"
+  batwatch --watcher poll file.sh <<< "q" | grep -q "Hello"
 }


### PR DESCRIPTION
The formatting flag to print the timestamp in epoch seconds in [GNU stat](https://www.gnu.org/software/coreutils/manual/html_node/stat-invocation.html) is `%Z` rather than `%z`. To fix this I made the following changes:

- In `determine_stat_variant()` verify that the result of the `stat` command is a numeric value. This required refactoring the function a bit. 

- In `watcher_poll_watch()` use `read` with a one second timeout instead of `sleep`. Exit if the user responds with `q`. This was to provide an escape path from the `while true` loop for the test.

Also, not exactly related:

- While initially debugging, I learned that the the script was not exiting as expected and an error message was being obscured by the subshell in the `OPT_WATCHER="$(determine_watcher)"` call. I changed the `determine_watcher()` function to assign `OPT_WATCHER` directly instead of printing it, and changed the caller line to `if ! determine_watcher`. I probably should have written a test around this, but I didn't think of it at the time and I kind of forgot the details.

- When testing I learned that `--clear` wasn't behaving as expected, because `main` was being executed from within a pager. I moved the `pager_exec` command from `main` to the `entr` and `bat` lines respectively to address this.

- I added a `-h`|`--help` flag.

I made these changes mostly for myself, but figured it would be nicer to submit the patch than just file a bug report.

A much simpler, one character fix would be to just change the `%z` to `%Z`. Feel free to disregard this patch and go that route if you'd prefer. 


