### PR TITLE
Fix error when using fzf to pick manpages

### DIFF
--- a/src/batman.sh
+++ b/src/batman.sh
@@ -61,7 +61,7 @@ if [[ "${#MAN_ARGS[@]}" -eq 0 ]] && [[ -z "$BATMAN_LEVEL" ]] && command -v "$EXE
 	# Convert the page(section) format to something that can be fed to the man command.
 	while read -r line; do
 		if [[ "$line" =~ ^(.*)\(([0-9]+)\)$ ]]; then
-			MAN_ARGS+=("${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}")
+			MAN_ARGS+=("${BASH_REMATCH[2]}" "$(echo ${BASH_REMATCH[1]} | xargs)")
 		fi
 	done <<< "$selected_page"	
 fi


### PR DESCRIPTION
- steps to reproduce error:
  - run batman with no arguments
  - pick any entry
  - script exits and man prints an error message similar to 'No manual entry for .k5identity  in section 5'

I speculated that this error was due to whitespace being attached to the second argument in the man call.
This commit fixes this error by piping the second argument through xargs to strip these spaces.

After applying this commit the script works as expected.