### PR TITLE
Use --hunk-headr-style

### DIFF
--- a/src/batdiff.sh
+++ b/src/batdiff.sh
@@ -77,7 +77,7 @@ done
 
 # Append arguments for delta/bat.
 BAT_ARGS+=("--terminal-width=${OPT_TERMINAL_WIDTH}" "--paging=never")
-DELTA_ARGS+=("--width=${OPT_TERMINAL_WIDTH}" "--paging=never" "--hunk-style=plain")
+DELTA_ARGS+=("--width=${OPT_TERMINAL_WIDTH}" "--paging=never" "--hunk-header-style=plain")
 
 if "$OPT_COLOR"; then
 	BAT_ARGS+=("--color=always")


### PR DESCRIPTION
Delta errors out on --hunk-style with:
```
error: Found argument '--hunk-style' which wasn't expected, or isn't valid in this context
```

This change is to use `--hunk-header-style`