### PR TITLE
batdiff: Fix use of deprecated `--hunk-style`

### DIFF
--- a/src/batdiff.sh
+++ b/src/batdiff.sh
@@ -77,7 +77,11 @@ done
 
 # Append arguments for delta/bat.
 BAT_ARGS+=("--terminal-width=${OPT_TERMINAL_WIDTH}" "--paging=never")
-DELTA_ARGS+=("--width=${OPT_TERMINAL_WIDTH}" "--paging=never" "--hunk-header-decoration-style=plain")
+DELTA_ARGS+=(
+	"--width=${OPT_TERMINAL_WIDTH}" 
+	"--paging=never" 
+	"--hunk-header-decoration-style=plain"
+)
 
 if "$OPT_COLOR"; then
 	BAT_ARGS+=("--color=always")

--- a/src/batdiff.sh
+++ b/src/batdiff.sh
@@ -77,7 +77,7 @@ done
 
 # Append arguments for delta/bat.
 BAT_ARGS+=("--terminal-width=${OPT_TERMINAL_WIDTH}" "--paging=never")
-DELTA_ARGS+=("--width=${OPT_TERMINAL_WIDTH}" "--paging=never" "--hunk-style=plain")
+DELTA_ARGS+=("--width=${OPT_TERMINAL_WIDTH}" "--paging=never" "--hunk-header-decoration-style=plain")
 
 if "$OPT_COLOR"; then
 	BAT_ARGS+=("--color=always")


### PR DESCRIPTION
Delta has deprecated `--hunk-style` in favor of its synonym `--hunk-header-decoration-style`. See https://github.com/dandavison/delta/releases/tag/0.12.0 for more info.