### PR TITLE
Fix bug where some man pages would fail to open

### DIFF
--- a/src/batman.sh
+++ b/src/batman.sh
@@ -60,7 +60,7 @@ if [[ "${#MAN_ARGS[@]}" -eq 0 ]] && [[ -z "$BATMAN_LEVEL" ]] && command -v "$EXE
 	
 	# Convert the page(section) format to something that can be fed to the man command.
 	while read -r line; do
-		if [[ "$line" =~ ^(.*)\(([0-9]+)\)$ ]]; then
+		if [[ "$line" =~ ^(.*)\(([0-9a-zA-Z]+)\)$ ]]; then
 			MAN_ARGS+=("${BASH_REMATCH[2]}" "$(echo ${BASH_REMATCH[1]} | xargs)")
 		fi
 	done <<< "$selected_page"	


### PR DESCRIPTION
Some man page sections contain alphabetical characters (e.g. 3bsd,
3perl, 3ssl.) This fixes a bug where selection of such pages would
not open any man page.