### PR TITLE
Add instructions for bat-extras on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ To install, first make sure you've added the [Gentoo Guru Overlay](https://wiki.
 emerge sys-apps/bat-extras
 ```
 
+### Fedora (Unofficial)
+`bat-extras` is available in an unofficial Fedora Copr
+[repository](https://copr.fedorainfracloud.org/coprs/awood/bat-extras/).
+**Note**: this package does not contain `prettybat` since `prettier` is not yet
+packaged for Fedora.
+
+Install the Copr plugin, enable the repository, and then install the package
+by running:
+
+```bash
+dnf install dnf-plugins-core 
+dnf copr enable awood/bat-extras
+dnf install bat-extras
+```
 
 &nbsp;
 


### PR DESCRIPTION
I packaged `bat-extras` for Fedora.  Right now it's an unofficial package in Copr which is Fedora's hub for community built packages.  I plan on submitting it for official inclusion, but that can take a little while.  I figured I'd update the docs so that people can start using the package now if they want.

I made the choice not to include `prettybat` since `prettier` is unavailable in Fedora.  Things like `rustfmt` and `black` are available, but adding them as package requirements pulls in all the language runtimes which creates a really large dependency web.  I'm somewhat on the fence about this decision since `prettybat` does technically work if a particular formatter isn't available.  I was going to seek guidance from the Fedora community on this issue but feedback here is appreciated as well.

Anyway, thanks for writing these scripts.  Now I have a great reason to type `batman` on my terminal all the time.