### PR TITLE
Fix parent process detection in batpipe

### DIFF
--- a/lib/proc.sh
+++ b/lib/proc.sh
@@ -11,7 +11,10 @@
 #     1   -- The target pid. If not provided, the script's parent is used.
 parent_executable() {
 	local target_pid="${1:-$PPID}"
-	ps -f -p "$target_pid" | tail -n 1 | awk '{for(i=8;i<=NF;i++) printf $i" "; printf "\n"}'
+	ps -f -p "$target_pid" \
+		| tail -n 1 \
+		| awk '{for(i=8;i<=NF;i++) printf $i" "; printf "\n"}' \
+		| cut -d' ' -f1
 }
 
 # Gets the PID of the parent executable file.

--- a/src/batpipe.sh
+++ b/src/batpipe.sh
@@ -69,7 +69,7 @@ if [[ "$#" -eq 0 ]]; then
 	#
 	# This will directly check if the parent is fish, since there's a
 	# good chance that `bash` or `sh` will be invoking fish.
-	if [[ "$(basename -- "$(parent_executable | cut -f1 -d' ')")" == "fish" ]]; then
+	if [[ "$(basename -- "$(parent_executable)")" == "fish" ]]; then
 		detected_shell="fish"
 	else
 		detected_shell="$(parent_shell)"
@@ -127,7 +127,7 @@ fi
 BATPIPE_PARENT_EXECUTABLE_PID="$PPID"
 for i in 1 2 3; do
 	BATPIPE_PARENT_EXECUTABLE="${BATPIPE_DEBUG_PARENT_EXECUTABLE:-$(parent_executable "$BATPIPE_PARENT_EXECUTABLE_PID")}"
-	BATPIPE_PARENT_EXECUTABLE_BASENAME="$(basename -- "${BATPIPE_PARENT_EXECUTABLE}" | cut -d' ' -f1)"
+	BATPIPE_PARENT_EXECUTABLE_BASENAME="$(basename -- "${BATPIPE_PARENT_EXECUTABLE}")"
 	BATPIPE_PARENT_EXECUTABLE_PID="$(parent_executable_pid "$BATPIPE_PARENT_EXECUTABLE_PID")"
 
 	if [[ "${BATPIPE_PARENT_EXECUTABLE_BASENAME}" = "less" ]]; then


### PR DESCRIPTION
Less is called with a filename, and if we basename CMD of less we get a basename of a filename, not a less executable. I think it's just a type that basename was piped to cut, CMD should be cut'ed before processed by basename.

As parent_executable is only used by batpipe, we can just cut CMD and extract program name.