### PR TITLE
Add --help to batgrep

### DIFF
--- a/src/batgrep.sh
+++ b/src/batgrep.sh
@@ -6,7 +6,31 @@
 # Issues:     https://github.com/eth-p/bat-extras/issues
 # -----------------------------------------------------------------------------
 
-usage() {
+
+# shellcheck disable=SC1090
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo ".")")/../lib" && pwd)"
+source "${LIB}/constants.sh"
+source "${LIB}/print.sh"
+source "${LIB}/pager.sh"
+source "${LIB}/opt.sh"
+source "${LIB}/opt_hook_color.sh"
+source "${LIB}/opt_hook_help.sh"
+source "${LIB}/opt_hook_pager.sh"
+source "${LIB}/opt_hook_version.sh"
+source "${LIB}/opt_hook_width.sh"
+source "${LIB}/version.sh"
+# -----------------------------------------------------------------------------
+# Init:
+# -----------------------------------------------------------------------------
+hook_color
+hook_help
+hook_pager
+hook_version
+hook_width
+# -----------------------------------------------------------------------------
+# Help:
+# -----------------------------------------------------------------------------
+show_help() {
     cat <<-'EOF'
 Quickly search through and highlight files using ripgrep.
 
@@ -113,27 +137,7 @@ Options passed directly to ripgrep:
 
       --ignore-file
 EOF
-    exit 1
 }
-
-# shellcheck disable=SC1090
-LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo ".")")/../lib" && pwd)"
-source "${LIB}/constants.sh"
-source "${LIB}/print.sh"
-source "${LIB}/pager.sh"
-source "${LIB}/opt.sh"
-source "${LIB}/opt_hook_color.sh"
-source "${LIB}/opt_hook_pager.sh"
-source "${LIB}/opt_hook_version.sh"
-source "${LIB}/opt_hook_width.sh"
-source "${LIB}/version.sh"
-# -----------------------------------------------------------------------------
-# Init:
-# -----------------------------------------------------------------------------
-hook_color
-hook_pager
-hook_version
-hook_width
 # -----------------------------------------------------------------------------
 # Options:
 # -----------------------------------------------------------------------------
@@ -192,9 +196,6 @@ resetargs
 SHIFTOPT_SHORT_OPTIONS="VALUE"
 while shiftopt; do
 	case "$OPT" in
-
-    # display help and quit
-    -h | --help) usage;;
 
 	# ripgrep options
 	[-]+([u]) ) ;;   # Ignore - handled in first loop.

--- a/src/batgrep.sh
+++ b/src/batgrep.sh
@@ -5,6 +5,117 @@
 # Repository: https://github.com/eth-p/bat-extras
 # Issues:     https://github.com/eth-p/bat-extras/issues
 # -----------------------------------------------------------------------------
+
+usage() {
+    cat <<-'EOF'
+Quickly search through and highlight files using ripgrep.
+
+Search through files or directories looking for matching regular expressions (or fixed strings with -F), and print the output using bat for an easy and syntax-highlighted experience.
+
+Usage: batgrep [OPTIONS] PATTERN [PATH...]
+
+Arguments:
+  [OPTIONS]
+          See Options below
+  PATTERN
+          Pattern passed to ripgrep
+  [PATH...]
+          Path(s) to search
+
+Options:
+  -i, --ingore-case:
+          Use case insensitive searching.
+
+  -s, --case-sensitive:
+          Use case sensitive searching.
+
+  -S, --smart-case:
+          Use smart case searching
+
+  -A, --after-context=[LINES]:
+          Display the next n lines after a matched line.
+
+  -B, --before-context=[LINES]:
+          Display the previous n lines before a matched line.
+
+  -C, --context=[LINES]:
+          A combination of --after-context and --before-context
+
+  -p, --search-pattern:
+          Tell pager to search for PATTERN. Currently supported pagers: less.
+
+      --no-follow:
+          Do not follow symlinks
+
+      --no-snip:
+          Do not show the snip decoration
+
+          This is automatically enabled when --context=0 or when bat --version is less than 0.12.x
+
+      --no-highlight:
+          Do not highlight matching lines.
+
+          This is automatically enabled when --context=0.
+
+      --color:
+          Force color output.
+
+      --no-color:
+          Force disable color output.
+
+      --paging=["never"/"always"]:
+          Enable/disable paging.
+
+      --pager=[PAGER]:
+          Specify the pager to use.
+
+      --terminal-wdith=[COLS]:
+          Generate output for the specified terminal width.
+
+      --no-seperator:
+          Disable printing separator between files
+
+Options passed directly to ripgrep:
+  -F, --fixed-strings
+
+  -U, --multiline
+
+  -P, --pcre2
+
+  -z, --search-zip
+
+  -w, --word-regexp
+
+      --one-file-system
+
+      --multiline-dotall
+
+      --ignore, --no-ignore
+
+      --crlf, --no-crlf
+
+      --hidden, --no-hidden
+
+  -E --encoding:
+          This is unsupported by bat, and may cause issues when trying to display unsupported encodings.
+
+  -g, --glob
+
+  -t, --type
+
+  -T, --type-not
+
+  -m, --max-count
+
+      --max-depth
+
+      --iglob
+
+      --ignore-file
+EOF
+    exit 1
+}
+
 # shellcheck disable=SC1090
 LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo ".")")/../lib" && pwd)"
 source "${LIB}/constants.sh"
@@ -81,6 +192,9 @@ resetargs
 SHIFTOPT_SHORT_OPTIONS="VALUE"
 while shiftopt; do
 	case "$OPT" in
+
+    # display help and quit
+    -h | --help) usage;;
 
 	# ripgrep options
 	[-]+([u]) ) ;;   # Ignore - handled in first loop.

--- a/test/snapshot/batgrep/test_help.stdout.snapshot
+++ b/test/snapshot/batgrep/test_help.stdout.snapshot
@@ -1,0 +1,104 @@
+Quickly search through and highlight files using ripgrep.
+
+Search through files or directories looking for matching regular expressions (or fixed strings with -F), and print the output using bat for an easy and syntax-highlighted experience.
+
+Usage: batgrep [OPTIONS] PATTERN [PATH...]
+
+Arguments:
+  [OPTIONS]
+          See Options below
+  PATTERN
+          Pattern passed to ripgrep
+  [PATH...]
+          Path(s) to search
+
+Options:
+  -i, --ingore-case:
+          Use case insensitive searching.
+
+  -s, --case-sensitive:
+          Use case sensitive searching.
+
+  -S, --smart-case:
+          Use smart case searching
+
+  -A, --after-context=[LINES]:
+          Display the next n lines after a matched line.
+
+  -B, --before-context=[LINES]:
+          Display the previous n lines before a matched line.
+
+  -C, --context=[LINES]:
+          A combination of --after-context and --before-context
+
+  -p, --search-pattern:
+          Tell pager to search for PATTERN. Currently supported pagers: less.
+
+      --no-follow:
+          Do not follow symlinks
+
+      --no-snip:
+          Do not show the snip decoration
+
+          This is automatically enabled when --context=0 or when bat --version is less than 0.12.x
+
+      --no-highlight:
+          Do not highlight matching lines.
+
+          This is automatically enabled when --context=0.
+
+      --color:
+          Force color output.
+
+      --no-color:
+          Force disable color output.
+
+      --paging=["never"/"always"]:
+          Enable/disable paging.
+
+      --pager=[PAGER]:
+          Specify the pager to use.
+
+      --terminal-wdith=[COLS]:
+          Generate output for the specified terminal width.
+
+      --no-seperator:
+          Disable printing separator between files
+
+Options passed directly to ripgrep:
+  -F, --fixed-strings
+
+  -U, --multiline
+
+  -P, --pcre2
+
+  -z, --search-zip
+
+  -w, --word-regexp
+
+      --one-file-system
+
+      --multiline-dotall
+
+      --ignore, --no-ignore
+
+      --crlf, --no-crlf
+
+      --hidden, --no-hidden
+
+  -E --encoding:
+          This is unsupported by bat, and may cause issues when trying to display unsupported encodings.
+
+  -g, --glob
+
+  -t, --type
+
+  -T, --type-not
+
+  -m, --max-count
+
+      --max-depth
+
+      --iglob
+
+      --ignore-file

--- a/test/suite/batgrep.sh
+++ b/test/suite/batgrep.sh
@@ -16,6 +16,15 @@ require_rg() {
 	fi
 }
 
+test:help() {
+    description "Test 'batgrep --help'"
+    snapshot stdout
+    batgrep --help
+
+    assert batgrep --help
+    batgrep --help | grep -q 'Usage'
+}
+
 test:version() {
 	description "Test 'batgrep --version'"
 	snapshot stdout


### PR DESCRIPTION
I really like batgrep and want to adopt it for my normal workflows. I was surprised that it didn't support `--help`, so I ported the options list from [here](https://github.com/eth-p/bat-extras/blob/7aa73f8989fad85e7b52095d3dfe9f7b89f952ae/doc/batgrep.md) to a `usage` function.

Clearly you have implementation preferences, but I couldn't see exactly where you would want the function, so I stuck it up at the top.

If you would like me to move it somewhere else or alter it in any way, please let me know and I'm happy to make the change.

<details>
<summary>here's what it currently looks like</summary>

```
$ src/batgrep.sh --help                                                            4:39PM
Quickly search through and highlight files using ripgrep.

Search through files or directories looking for matching regular expressions (or fixed strings with -F), and print the output using bat for an easy and syntax-highlighted experience.

Usage: batgrep [OPTIONS] PATTERN [PATH...]

Arguments:
  [OPTIONS]
          See Options below
  PATTERN
          Pattern passed to ripgrep
  [PATH...]
          Path(s) to search

Options:
  -i, --ingore-case:
          Use case insensitive searching.

  -s, --case-sensitive:
          Use case sensitive searching.

  -S, --smart-case:
          Use smart case searching

  -A, --after-context=[LINES]:
          Display the next n lines after a matched line.

  -B, --before-context=[LINES]:
          Display the previous n lines before a matched line.

  -C, --context=[LINES]:
          A combination of --after-context and --before-context

  -p, --search-pattern:
          Tell pager to search for PATTERN. Currently supported pagers: less.

      --no-follow:
          Do not follow symlinks

      --no-snip:
          Do not show the snip decoration

          This is automatically enabled when --context=0 or when bat --version is less than 0.12.x

      --no-highlight:
          Do not highlight matching lines.

          This is automatically enabled when --context=0.

      --color:
          Force color output.

      --no-color:
          Force disable color output.

      --paging=["never"/"always"]:
          Enable/disable paging.

      --pager=[PAGER]:
          Specify the pager to use.

      --terminal-wdith=[COLS]:
          Generate output for the specified terminal width.

      --no-seperator:
          Disable printing separator between files

Options passed directly to ripgrep:
  -F, --fixed-strings

  -U, --multiline

  -P, --pcre2

  -z, --search-zip

  -w, --word-regexp

      --one-file-system

      --multiline-dotall

      --ignore, --no-ignore

      --crlf, --no-crlf

      --hidden, --no-hidden

  -E --encoding:
          This is unsupported by bat, and may cause issues when trying to display unsupported encodings.

  -g, --glob

  -t, --type

  -T, --type-not

  -m, --max-count

      --max-depth

      --iglob

      --ignore-file
```

</details>
