### PR TITLE
fix typos in batgrep help

### DIFF
--- a/src/batgrep.sh
+++ b/src/batgrep.sh
@@ -47,7 +47,7 @@ Arguments:
           Path(s) to search
 
 Options:
-  -i, --ingore-case:
+  -i, --ignore-case:
           Use case insensitive searching.
 
   -s, --case-sensitive:
@@ -93,10 +93,10 @@ Options:
       --pager=[PAGER]:
           Specify the pager to use.
 
-      --terminal-wdith=[COLS]:
+      --terminal-width=[COLS]:
           Generate output for the specified terminal width.
 
-      --no-seperator:
+      --no-separator:
           Disable printing separator between files
 
 Options passed directly to ripgrep:

--- a/test/snapshot/batgrep/test_help.stdout.snapshot
+++ b/test/snapshot/batgrep/test_help.stdout.snapshot
@@ -13,7 +13,7 @@ Arguments:
           Path(s) to search
 
 Options:
-  -i, --ingore-case:
+  -i, --ignore-case:
           Use case insensitive searching.
 
   -s, --case-sensitive:
@@ -59,10 +59,10 @@ Options:
       --pager=[PAGER]:
           Specify the pager to use.
 
-      --terminal-wdith=[COLS]:
+      --terminal-width=[COLS]:
           Generate output for the specified terminal width.
 
-      --no-seperator:
+      --no-separator:
           Disable printing separator between files
 
 Options passed directly to ripgrep:


### PR DESCRIPTION
I noticed them as soon as #97 was merged, of course. Apologies for the errors.
