### PR TITLE
Add Elixir mix format support

### DIFF
--- a/doc/prettybat.md
+++ b/doc/prettybat.md
@@ -21,22 +21,23 @@ See `man bat` for more information.
 
 ## Languages
 
-| Language             | Formatter                                                   |
-| -------------------- | ----------------------------------------------------------- |
-| JavaScript (JS, JSX) | [prettier](https://prettier.io/)                            |
-| TypeScript (TS, TSX) | [prettier](https://prettier.io/)                            |
-| CSS, SCSS, SASS      | [prettier](https://prettier.io/)                            |
-| Markdown             | [prettier](https://prettier.io/)                            |
-| JSON                 | [prettier](https://prettier.io/)                            |
-| YAML                 | [prettier](https://prettier.io/)                            |
-| HTML                 | [prettier](https://prettier.io/)                            |
-| SVG                  | [prettier](https://prettier.io/)                            |
-| Rust                 | [rustfmt](https://github.com/rust-lang/rustfmt)             |
-| Bash                 | [shfmt](https://github.com/mvdan/sh)                        |
-| C                    | [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) |
-| C++                  | [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) |
-| Objective-C          | [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) |
-| Python               | [black](https://black.readthedocs.io/)                      |
+| Language             | Formatter                                                       |
+| -------------------- | --------------------------------------------------------------- |
+| JavaScript (JS, JSX) | [prettier](https://prettier.io/)                                |
+| TypeScript (TS, TSX) | [prettier](https://prettier.io/)                                |
+| CSS, SCSS, SASS      | [prettier](https://prettier.io/)                                |
+| Markdown             | [prettier](https://prettier.io/)                                |
+| JSON                 | [prettier](https://prettier.io/)                                |
+| YAML                 | [prettier](https://prettier.io/)                                |
+| HTML                 | [prettier](https://prettier.io/)                                |
+| SVG                  | [prettier](https://prettier.io/)                                |
+| Rust                 | [rustfmt](https://github.com/rust-lang/rustfmt)                 |
+| Bash                 | [shfmt](https://github.com/mvdan/sh)                            |
+| C                    | [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)     |
+| C++                  | [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)     |
+| Objective-C          | [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)     |
+| Python               | [black](https://black.readthedocs.io/)                          |
+| Elixir               | [mix format](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html) |
 
 
 

--- a/src/prettybat.sh
+++ b/src/prettybat.sh
@@ -22,7 +22,7 @@ hook_version
 # Formatters:
 # -----------------------------------------------------------------------------
 
-FORMATTERS=("prettier" "rustfmt" "shfmt" "clangformat" "black")
+FORMATTERS=("prettier" "rustfmt" "shfmt" "clangformat" "black", "mix_format")
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -118,6 +118,26 @@ formatter_black_process() {
 	return $?
 }
 
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+formatter_mix_format_supports() {
+	case "$1" in
+		.ex | \
+		.exs | \
+		.eex | \
+		.heex)
+		return 0
+		;;
+	esac
+
+	return 1
+}
+
+formatter_mix_format_process() {
+	mix format
+	return $?
+}
+
 # -----------------------------------------------------------------------------
 # Functions:
 # -----------------------------------------------------------------------------
@@ -145,6 +165,8 @@ map_language_to_extension() {
 	rust | rs)                  ext=".rs" ;;
 	graphql | gql)              ext=".graphql" ;;
 	python | py)                ext=".py" ;;
+	elixir | ex)                ext=".ex" ;;
+	exs)                        ext=".exs" ;;
 	esac
 
 	echo "$ext"


### PR DESCRIPTION
Elixir has [a built-in package manager called `mix`](https://hex.pm/docs/usage), and it has [a built-in command `mix format`](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html) that will format all Elixir code in a given Mix project. 😄 