### PR TITLE
batman: redirect stderr to /dev/null when rendering preview

### DIFF
--- a/src/batman.sh
+++ b/src/batman.sh
@@ -75,7 +75,7 @@ if [[ "${#MAN_ARGS[@]}" -eq 0 ]] && [[ -z "$BATMAN_LEVEL" ]] && command -v "$EXE
 		echo {1} \
 		| sed 's/, /\n/g;' \
 		| sed 's/\([^(]*\)(\([0-9A-Za-z ]\))/\2\t\1/g' \
-		| BAT_STYLE=plain xargs -n2 batman --color=always --paging=never
+		| BAT_STYLE=plain xargs -n2 batman --color=always --paging=never 2> /dev/null
 	")"
 	
 	if [[ -z "$selected_page" ]]; then


### PR DESCRIPTION
To avoid preview being flooded by garbage warnings.