### PR TITLE
Batman unalias

### DIFF
--- a/src/batman.sh
+++ b/src/batman.sh
@@ -92,13 +92,21 @@ if [[ "${#MAN_ARGS[@]}" -eq 0 ]] && [[ -z "$BATMAN_LEVEL" ]] && command -v "$EXE
 	if [[ -z "$selected_page" ]]; then
 		exit 0
 	fi
+
+	# Some entries from `man -k .` may include "synonyms" of a man page's title.
+	# For example, the manual for kubectl-edit will appear as:
+	#
+	#   kubectl-edit(1), kubectl edit(1) - Edit a resource on the server
+	#
+	# `man` only needs one name/title, so we're taking the first one here.
+	selected_page_unaliased="$(echo "$selected_page" | cut -d, -f1)"
 	
 	# Convert the page(section) format to something that can be fed to the man command.
 	while read -r line; do
 		if [[ "$line" =~ ^(.*)\(([0-9a-zA-Z ]+)\) ]]; then
 			MAN_ARGS+=("${BASH_REMATCH[2]}" "$(echo ${BASH_REMATCH[1]} | xargs)")
 		fi
-	done <<< "$selected_page"	
+	done <<< "$selected_page_unaliased"
 fi
 
 # Run man.


### PR DESCRIPTION
Hi:) I noticed that some manual entries, specifically `kubectl`-related, have this weird comma in their name which indicates synonyms I suppose? See the output of `man -k . | grep kubectl` on MacOS installed via Homebrew:

```
kubectl-alpha(1), kubectl alpha(1) - Commands for features in alpha
kubectl-annotate(1), kubectl annotate(1) - Update the annotations on a resource
kubectl-api-resources(1), kubectl api-resources(1) - Print the supported API resources on the server
kubectl-api-versions(1), kubectl api-versions(1) - Print the supported API versions on the server, in the form of "group/version"
kubectl-apply(1), kubectl apply(1) - Apply a configuration to a resource by file name or stdin
...
```

These synonyms caused batman to fail:

```
$ src/batman.sh
<select here kubectl-events...>
No manual entry for kubectl-events(1), kubectl events
```


This patch ignores everything after the first comma, taking only the "main" name. 
Thanks for the project:)