### PR TITLE
batpipe: Add support for more file formats

### DIFF
--- a/doc/batpipe.md
+++ b/doc/batpipe.md
@@ -32,8 +32,14 @@ Like [lesspipe](https://github.com/wofr06/lesspipe), `batpipe` is designed to wo
 | Directories          | `eza`, `ls`                 |
 | `*.tar`, `*.tar.gz`  | `tar`                       |
 | `*.zip`, `*.jar`     | `unzip`                     |
+| `*.7z`               | `7z`                        |
 | `*.gz`               | `gunzip`                    |
+| `*.bz2`              | `bzip2`                     |
 | `*.xz`               | `xz`                        |
+| `*.lz4`              | `lz4`                       |
+| `*.lz`               | `lzip`                      |
+| `*.lzo`              | `lzop`                      |
+| `*.zst`              | `zstd`                      |
 
 
 ## External Viewers


### PR DESCRIPTION
- Add support for `.tar.xz` and `.tar.zst`. These use the same options for both Gnu tar and BSD tar.
- Add support for `.7z`. I think this is used to some extent not only in Windows but also in Unix-like systems.
- Add support for bzip2, LZ4, lzip, lzop and zstd. These are supported by GNU tar and/or BSD tar.

## Comparison of options for GNU tar and BSD tar

| Algorithm | Option   | GNU tar            | BSD tar            |
| --------- | -------- | ------------------ | ------------------ |
| bzip2     | `-j`     | :white_check_mark: | :white_check_mark: |
| gzip      | `-z`     | :white_check_mark: | :white_check_mark: |
| LZ4       | `--lz4`  | :x:                | :white_check_mark: |
| lzip      | `--lzip` | :white_check_mark: | :x:                |
| lzop      | `--lzop` | :white_check_mark: | :white_check_mark: |
| xz        | `-J`     | :white_check_mark: | :white_check_mark: |
| zst       | `--zstd` | :white_check_mark: | :white_check_mark: |

## References

- <https://www.gnu.org/software/tar/manual/tar.html#gzip>
- <https://man.freebsd.org/cgi/man.cgi?tar(1)>
- <https://manpages.debian.org/bookworm/p7zip-full/7z.1.en.html>