### PR TITLE
batdiff: Support filenames with special characters

### DIFF
--- a/src/batdiff.sh
+++ b/src/batdiff.sh
@@ -155,8 +155,8 @@ print_bat_diff() {
 
 	# Diff git file.
 	if "$SUPPORTS_BAT_DIFF"; then
-		"$EXECUTABLE_GIT" diff "${GIT_ARGS[@]}" --name-only "${files[0]}" \
-			| xargs "$EXECUTABLE_BAT" --diff --diff-context="$OPT_CONTEXT" "${BAT_ARGS[@]}"
+		"$EXECUTABLE_GIT" diff "${GIT_ARGS[@]}" --name-only -z "${files[0]}" \
+			| xargs --null "$EXECUTABLE_BAT" --diff --diff-context="$OPT_CONTEXT" "${BAT_ARGS[@]}"
 	else
 		"$EXECUTABLE_GIT" diff "${GIT_ARGS[@]}" "${files[0]}" | "$EXECUTABLE_BAT" --language=diff - "${BAT_ARGS[@]}"
 	fi


### PR DESCRIPTION
This PR added `-z` flag to git and `--null` flag to xargs.

Currently if (for whatever reason) a file in the repo has special characters in its name, including space, new line, etc., batdiff would malfunction. With filenames being handled in form of NULL-terminated strings, the issue is resolved.