### PR TITLE
lib/opts.sh: fix prefixes with embedded '-'

### DIFF
--- a/lib/opt.sh
+++ b/lib/opt.sh
@@ -181,7 +181,7 @@ shiftval() {
 	fi
 
 	# Error if no value is provided.
-	if [[ "$OPT_VAL" =~ -.* ]]; then
+	if [[ "$OPT_VAL" =~ ^-.* ]]; then
 		printc "%{RED}%s: '%s' requires a value%{CLEAR}\n" "$PROGRAM" "$ARG"
 		exit 1
 	fi


### PR DESCRIPTION
If a `--prefix` path has an embedded '-', shiftval incorrectly detects it as a flag.