### PR TITLE
test: Add regression test for less file-path detection

### DIFF
--- a/test/shimexec/less
+++ b/test/shimexec/less
@@ -12,10 +12,27 @@ EOF
 exit 0
 fi
 
-FILES=()
-while [[ $# -gt 0 ]]; do
-    -*) : ;;
-    *)  FILES+=("$1")
+# Re-exec with argv[0] set to `less` (like the fish/nu shims) so this process
+# is reported as `less` by `ps`. batpipe identifies its parent process by name;
+# a plain script would show up as `bash .../less` and hide us.
+if [[ -z "${_LESS_SHIM_REEXEC:-}" ]]; then
+	export _LESS_SHIM_REEXEC=1
+	exec -a "${SHIM_ARGV0:-less}" bash "$0" "$@"
+fi
+
+# Collect file operands, ignoring options -- like the real less CLI.
+files=()
+for arg; do
+	[[ "$arg" == -* ]] || files+=("$arg")
 done
 
-cat "${FILES[@]}"
+# Honor an input-pipe LESSOPEN preprocessor (`|command %s`) the way real less
+# does: feed each file through it. Otherwise just print the file.
+for file in "${files[@]}"; do
+	if [[ "${LESSOPEN-}" == "|"* ]]; then
+		command="${LESSOPEN#|}"
+		eval "${command//%s/$file}"
+	else
+		cat "$file"
+	fi
+done

--- a/test/suite/batpipe.sh
+++ b/test/suite/batpipe.sh
@@ -42,6 +42,23 @@ test:detected_nu_shell() {
 	grep '^\$env' <<< "$output" >/dev/null || fail 'Detected wrong shell when checking parent process.'
 }
 
+test:detected_less_with_path_argument() {
+	description "Test it detects less when less opens a file by an absolute path."
+
+	# Drive less, letting it invoke batpipe as its LESSOPEN preprocessor, with a
+	# file opened by an absolute path -- exactly how files are normally opened
+	# (`less /home/user/file.txt`). less's command line then ends in that path;
+	# batpipe must detect "less" from the executable name only. Taking the
+	# basename of the *whole* command line yields the file's basename instead,
+	# so batpipe wrongly concludes it is not inside less and disables color.
+	export BATPIPE_DEBUG=1
+	export LESSOPEN="|$(batpipe_path) %s"
+
+	output="$(less "${PWD}/file.txt" 2>&1)"
+	grep 'BATPIPE_INSIDE_LESS: true' <<< "$output" >/dev/null \
+		|| fail "Did not detect less as the parent when opening a file by an absolute path."
+}
+
 test:viewer_gzip() {
 	description "Test it can view .gz files."
 	command -v "gunzip" &>/dev/null || skip "Test requires gunzip."


### PR DESCRIPTION
Adds a regression test for the batpipe parent-detection bug reported in #149: syntax color is lost when `less` opens a file with slashes in the path, because batpipe takes the basename of less's whole `ps` command line and sees the filename instead of `less`.

To exercise this, the `less` test shim is extended to honor a piped `LESSOPEN` and to re-exec with `argv[0]=less` (mirroring the existing `fish`/`nu` shims), since the suite mocks `less`.

**Draft — depends on #96.** This PR contains only the test, so the suite is red until the fix in #96 lands. I verified the test passes on top of #96's change.

Regression test for #149. Fix: #96.
